### PR TITLE
Convert ViewScanner into an interface

### DIFF
--- a/a11y/src/main/java/com/filip/babic/a11y/scanner/base/ViewScanner.kt
+++ b/a11y/src/main/java/com/filip/babic/a11y/scanner/base/ViewScanner.kt
@@ -4,11 +4,12 @@ import android.view.View
 import com.filip.babic.a11y.report.model.ViewReportItem
 
 /**
- * Basic abstract View scanner.
+ * Common interface for View scanners.
  */
-internal abstract class ViewScanner {
+internal interface ViewScanner {
 
-  abstract fun <T : View> getViewReportItems(view: T): List<ViewReportItem>
+  fun <T : View> getViewReportItems(view: T): List<ViewReportItem>
 
-  abstract fun canScan(view: View): Boolean
+  fun canScan(view: View): Boolean
+
 }

--- a/a11y/src/main/java/com/filip/babic/a11y/scanner/general/GeneralViewScanner.kt
+++ b/a11y/src/main/java/com/filip/babic/a11y/scanner/general/GeneralViewScanner.kt
@@ -6,9 +6,9 @@ import com.filip.babic.a11y.scanner.base.ViewScanner
 import com.filip.babic.a11y.utils.hasBigEnoughTouchArea
 
 /**
- * Scans generic [View] items, to  produce [ViewItemReport]s about them.
+ * Scans generic [View] items, to  produce [ViewReportItem]s about them.
  */
-internal class GeneralViewScanner : ViewScanner() {
+internal class GeneralViewScanner : ViewScanner {
 
   // TODO: Add guidelines on using `View.Gone` instead of `0dp` when removing components from UI
   override fun <T : View> getViewReportItems(view: T): List<ViewReportItem> {

--- a/a11y/src/main/java/com/filip/babic/a11y/scanner/image/ImageViewScanner.kt
+++ b/a11y/src/main/java/com/filip/babic/a11y/scanner/image/ImageViewScanner.kt
@@ -5,12 +5,11 @@ import android.widget.ImageView
 import com.filip.babic.a11y.report.model.ViewReportItem
 import com.filip.babic.a11y.scanner.base.ViewScanner
 import com.filip.babic.a11y.utils.isContentDescriptionValid
-import com.filip.babic.a11y.utils.shouldBeMoreDescriptive
 
 /**
  * Scans [ImageView] types, and produces its [ViewReportItem]s.
  */
-internal class ImageViewScanner : ViewScanner() {
+internal class ImageViewScanner : ViewScanner {
 
   override fun <T : View> getViewReportItems(view: T): List<ViewReportItem> {
     val imageView = view as ImageView

--- a/a11y/src/main/java/com/filip/babic/a11y/scanner/text/EditTextScanner.kt
+++ b/a11y/src/main/java/com/filip/babic/a11y/scanner/text/EditTextScanner.kt
@@ -7,7 +7,7 @@ import com.filip.babic.a11y.scanner.base.ViewScanner
 import com.filip.babic.a11y.utils.isAutofillHintValid
 import com.filip.babic.a11y.utils.isHintValid
 
-internal class EditTextScanner : ViewScanner() {
+internal class EditTextScanner : ViewScanner {
 
   override fun canScan(view: View): Boolean = view is EditText
 

--- a/a11y/src/main/java/com/filip/babic/a11y/scanner/text/TextViewScanner.kt
+++ b/a11y/src/main/java/com/filip/babic/a11y/scanner/text/TextViewScanner.kt
@@ -11,7 +11,7 @@ import com.filip.babic.a11y.utils.isTextContrastCorrect
 /**
  * Scans [TextView]s to produce [ViewReportItem]s for them.
  */
-internal class TextViewScanner : ViewScanner() {
+internal class TextViewScanner : ViewScanner {
 
   override fun <T : View> getViewReportItems(view: T): List<ViewReportItem> {
     val textView = view as TextView


### PR DESCRIPTION
Since `ViewScanner` doesn't hold any state or implementation, it can be more lightweight as an interface 😄 